### PR TITLE
Revert "Tag Resolver as controller.argument_value_resolver"

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -4,6 +4,5 @@ services:
     autoconfigure: true
     public: true
 
-  webignition\SymfonyEncapsulatingRequestResolver\Services\Resolver:
-    tags:
-      - { name: controller.argument_value_resolver, priority: 50 }
+  webignition\SymfonyEncapsulatingRequestResolver\Services\:
+    resource: '../../Services/'


### PR DESCRIPTION
Reverts webignition/symfony-encapsulating-request-resolver#11

Such tagging is not recognised by apps using the bundle.